### PR TITLE
Fix build errors by removing pnpm usage

### DIFF
--- a/website-source/package.json
+++ b/website-source/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "yes | pnpm install && vite",
-    "build": "yes | pnpm install && rm -rf node_modules/.vite-temp && tsc -b && vite build",
-    "lint": "yes | pnpm install && eslint .",
-    "preview": "yes | pnpm install && vite preview"
+    "dev": "vite",
+    "build": "rm -rf node_modules/.vite-temp && tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
## Summary
- remove pnpm install commands from website scripts

## Testing
- `npm run lint` *(fails: ESLint configuration missing)*
- `npm install` *(fails: 403 Forbidden because npm registry can't be reached)*
- `npm run build` *(fails: TypeScript errors, likely due to outdated deps)*

------
https://chatgpt.com/codex/tasks/task_e_685378f40d54832587b28763db4f29fe