### PR TITLE
Fix tsconfig defaults

### DIFF
--- a/website-source/tsconfig.app.json
+++ b/website-source/tsconfig.app.json
@@ -3,7 +3,15 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "noEmit": true,
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "target": "es2016",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "downlevelIteration": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*"

--- a/website-source/tsconfig.json
+++ b/website-source/tsconfig.json
@@ -11,7 +11,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "rollup/parseAst": ["./node_modules/rollup/dist/parseAst.d.ts"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- update tsconfig paths for Rollup dependency
- enable modern module resolution and interop

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68537c3e5ee08325917e9d42abac7d7d