### PR TITLE
Fix rollup build error by using npm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,9 +38,8 @@ jobs:
       run: |
         cd website-source
         rm -rf node_modules package-lock.json
-        corepack enable
-        pnpm install
-        pnpm run build
+        npm install
+        npm run build
         cp -r dist/* ../website/
         
     - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- use npm instead of pnpm during website build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685389076cf08325b4e8f26fc696ffd8