### PR TITLE
Fix build by switching to pnpm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,13 +33,17 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '18'
+        cache: 'pnpm'
+
+    - name: Enable pnpm
+      run: corepack enable
 
     - name: Build website
       run: |
         cd website-source
-        rm -rf node_modules package-lock.json
-        npm install
-        npm run build
+        rm -rf node_modules
+        pnpm install --frozen-lockfile
+        pnpm run build
         cp -r dist/* ../website/
         
     - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- use pnpm for Node install and build steps
- enable pnpm caching via `setup-node`

## Testing
- `pnpm install --frozen-lockfile` *(fails: Cannot download packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68538d7092588325830bc0129444e0d3