### PR TITLE
Fix GitHub Pages deployment issues

### DIFF
--- a/data-tools/update_all_data.sh
+++ b/data-tools/update_all_data.sh
@@ -144,25 +144,29 @@ fi
 success_log "Website data files updated"
 
 # 8. Rebuild website
-info_log "Step 11: Rebuilding website..."
-cd website-source
-
-# Install dependencies if needed
-if [ ! -d "node_modules" ] || [ "$FULL_UPDATE" = true ]; then
-    info_log "Installing/updating dependencies..."
-    npm install
-fi
-
-# Build website
-if npm run build; then
-    success_log "Website built successfully"
+if [ "$CI" = "true" ]; then
+    info_log "Step 11: Skipping website build in CI"
 else
-    error_log "Website build failed"
-    cd "$WORKSPACE_DIR"
-    exit 1
-fi
+    info_log "Step 11: Rebuilding website..."
+    cd website-source
 
-cd "$WORKSPACE_DIR"
+    # Install dependencies if needed
+    if [ ! -d "node_modules" ] || [ "$FULL_UPDATE" = true ]; then
+        info_log "Installing/updating dependencies..."
+        npm install
+    fi
+
+    # Build website
+    if npm run build; then
+        success_log "Website built successfully"
+    else
+        error_log "Website build failed"
+        cd "$WORKSPACE_DIR"
+        exit 1
+    fi
+
+    cd "$WORKSPACE_DIR"
+fi
 
 # 9. Generate update report
 info_log "Step 11: Generating update report..."

--- a/website-source/index.html
+++ b/website-source/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/website-source/vite.config.ts
+++ b/website-source/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
 export default defineConfig({
+  base: "/jewhatetrends/",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- skip website build in CI so the workflow can use Node 18
- update Vite config with repo base path
- use a relative path for the entry script

## Testing
- `node --version`
- `cat /tmp/build.log | head -n 5` *(fails: ELIFECYCLE)*
- `cat /tmp/install.log | tail -n 5` *(fails: No authorization header)*

------
https://chatgpt.com/codex/tasks/task_e_68539466e3788325a3449cc5a492550d