### PR TITLE
Fix pnpm setup in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,14 +29,18 @@ jobs:
         chmod +x update_all_data.sh
         ./update_all_data.sh
 
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: 8
+        run_install: false
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'pnpm'
-
-    - name: Enable pnpm
-      run: corepack enable
+        cache-dependency-path: website-source/pnpm-lock.yaml
 
     - name: Build website
       run: |


### PR DESCRIPTION
## Summary
- install pnpm before using setup-node cache
- configure cache path for pnpm lockfile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685398a8b7208325a875eb5953ec9a98