### PR TITLE
Fix lockfile compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:
-        version: 8
+        version: 9
         run_install: false
 
     - name: Setup Node.js


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to install pnpm v9 so that the build can use the existing lockfile

## Testing
- `python -m pip install -r data-tools/requirements.txt` *(fails: cannot connect to pypi.org)*
- `pnpm install --frozen-lockfile` *(fails: cannot connect to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68539b2942b88325ae4bbf2e7596f7e5