### PR TITLE
Fix TS build error in website

### DIFF
--- a/website-source/tsconfig.node.json
+++ b/website-source/tsconfig.node.json
@@ -2,8 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "node16",
     "types": ["node"],
     "esModuleInterop": true
   },


### PR DESCRIPTION
## Summary
- update `module` and `moduleResolution` in `tsconfig.node.json` so TypeScript can resolve `rollup/parseAst`

## Testing
- `pnpm exec tsc -b`
- `pnpm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6853f0c789788325b4114b3afb354211