### PR TITLE
Fix GitHub Pages deploy permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 2 * * 1'  # Weekly on Monday at 2 AM UTC
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- set `contents: write` permissions for pages deployment

## Testing
- `pnpm test` *(fails: missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853f6ef4df8832580e7bb535da5d08c