### PR TITLE
Fix Google Trends date range

### DIFF
--- a/data-tools/final_trends_collector.py
+++ b/data-tools/final_trends_collector.py
@@ -8,7 +8,7 @@ import json
 import pandas as pd
 import requests
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 import time
 import urllib.parse
 
@@ -195,7 +195,14 @@ def main():
     urls = load_trends_urls()
     print(f"🔗 Configured for {len(urls)} trend categories")
 
-    start_date = "2020-06-18"
+    # Google Trends can lag a few days behind. To mimic the UI's
+    # "Past 12 months" view we start a few days earlier than exactly
+    # one year ago. This provides a small buffer so the resulting
+    # dataset aligns with the date range returned by the web UI.
+    DAYS_BUFFER = 4
+    start_date = (datetime.now() - timedelta(days=365 + DAYS_BUFFER)).strftime(
+        "%Y-%m-%d"
+    )
     end_date = datetime.now().strftime("%Y-%m-%d")
     
     # Prepare session with cookies


### PR DESCRIPTION
## Summary
- add a small date buffer to the Google Trends collector so the range mirrors the UI's 12‑month view

## Testing
- `python3 -m py_compile data-tools/final_trends_collector.py`

------
https://chatgpt.com/codex/tasks/task_e_6854859973f88325b7c756af53e7c8d5