### PR TITLE
Improve automatic ADL cookie handling

### DIFF
--- a/data-tools/collect_adl_data.py
+++ b/data-tools/collect_adl_data.py
@@ -274,13 +274,15 @@ def main():
         session = collector.fetch_fresh_cookies()
         success = collector.collect_all_pages(session)
     else:
-        logger.info("No collection method specified")
-        logger.info("Usage:")
-        logger.info("  --cookies 'cookie_string'  : Use provided cookies")
-        logger.info("  --auto-cookies             : Try automatic cookie discovery")
-        logger.info("  --fetch-cookies            : Fetch fresh cookies then collect")
-        logger.info("  --instructions             : Show manual collection guide")
-        return
+        logger.info("No options supplied, attempting automatic collection")
+        success = collector.auto_cookie_attempt()
+        if not success:
+            logger.info("Usage:")
+            logger.info("  --cookies 'cookie_string'  : Use provided cookies")
+            logger.info("  --auto-cookies             : Try automatic cookie discovery")
+            logger.info("  --fetch-cookies            : Fetch fresh cookies then collect")
+            logger.info("  --instructions             : Show manual collection guide")
+            return
     
     if success:
         logger.info("🎉 ADL data collection completed successfully!")


### PR DESCRIPTION
## Summary
- default to using `auto_cookie_attempt()` when no options are supplied
- only print usage instructions when the automatic attempt fails

## Testing
- `python3 -m py_compile data-tools/collect_adl_data.py`


------
https://chatgpt.com/codex/tasks/task_e_6854a736193c83259a71930c5ae5c085