### PR TITLE
Fix dtype assignment in geographic enhancer

### DIFF
--- a/data-tools/enhance_geographic_data.py
+++ b/data-tools/enhance_geographic_data.py
@@ -20,6 +20,11 @@ def enhance_geographic_data():
     
     # Create enhanced copy
     enhanced_df = df.copy()
+
+    # Ensure location columns use object dtype so string assignment works cleanly
+    for col in ['city', 'county', 'state']:
+        if col in enhanced_df.columns:
+            enhanced_df[col] = enhanced_df[col].astype('object')
     
     # 1. Fix Los Angeles identification
     print("\n🌴 Processing Los Angeles data...")


### PR DESCRIPTION
## Summary
- prevent pandas dtype warnings when assigning location fields

## Testing
- `python data-tools/multi_source_integrator.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6854b2d4cbc083259506ffc9af094862